### PR TITLE
chore: normalise engines.node to >=22 + bump pnpm to 10.32.1

### DIFF
--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -1,0 +1,6 @@
+---
+"@benhigham/stylelint-config": patch
+---
+
+- Normalise `engines.node` to `>=22` (was `>=22.15.0`) for consistency with other config repos
+- Bump `packageManager` to `pnpm@10.32.1`

--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -1,5 +1,5 @@
 ---
-"@benhigham/stylelint-config": patch
+'@benhigham/stylelint-config': patch
 ---
 
 - Normalise `engines.node` to `>=22` (was `>=22.15.0`) for consistency with other config repos

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "exports": "./src/index.js",
   "sideEffects": false,
   "engines": {
-    "node": ">=22.15.0"
+    "node": ">=22"
   },
-  "packageManager": "pnpm@10.15.0",
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## What

Normalise `engines.node` to match other config repos and bump pnpm.

## Changes

- `engines.node`: `>=22.15.0` → `>=22` (consistency with `commitlint-config` convention)
- `packageManager`: `pnpm@10.15.0` → `pnpm@10.32.1`
- Changeset: patch bump (no functional change)